### PR TITLE
[Timer] Round zero measurements to the resolution of the timer

### DIFF
--- a/Sources/CollectionsBenchmark/Basics/Tick.swift
+++ b/Sources/CollectionsBenchmark/Basics/Tick.swift
@@ -28,6 +28,16 @@ public struct Tick {
     precondition(r == 0, "clock_gettime failure")
     return Tick(_value: now)
   }
+  
+  public static var resolution: Time {
+    guard #available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) else {
+      fatalError("Please enable USE_FOUNDATION_DATE")
+    }
+    var res = timespec()
+    let r = clock_getres(CLOCK_MONOTONIC_RAW, &res)
+    precondition(r == 0, "clock_getres failure")
+    return Tick(_value: res).elapsedTime(since: Tick(_value: timespec(tv_sec: 0, tv_nsec: 0)))
+  }
 
   public func elapsedTime(since start: Tick) -> Time {
     let s = Double(_value.tv_sec - start._value.tv_sec)
@@ -53,6 +63,10 @@ public struct Tick {
 
   public func elapsedTime(since start: Tick) -> Time {
     Time(Double(_value.timeIntervalSince(start._value)))
+  }
+  
+  public static var resolution: Time {
+    .nanosecond
   }
 }
 #endif

--- a/Sources/CollectionsBenchmark/Basics/Time.swift
+++ b/Sources/CollectionsBenchmark/Basics/Time.swift
@@ -144,3 +144,9 @@ extension Time {
     return Time(seconds / TimeInterval(size.rawValue))
   }
 }
+
+extension Time {
+  internal func _orIfZero(_ time: Time) -> Time {
+    self > .zero ? self : time
+  }
+}

--- a/Sources/CollectionsBenchmark/Benchmark/Task.swift
+++ b/Sources/CollectionsBenchmark/Benchmark/Task.swift
@@ -68,12 +68,8 @@ extension Task {
     // we run short tasks multiple times, and we adjust iteration counts as
     // we go.
 
-    let (firstTime, hasNestedMeasurement) =
-      Timer._measureFirst(instance)
-
-    precondition(firstTime > .zero,
-                 "Task '\(title)' at size \(size) measured at zero seconds")
-
+    let (firstTime, hasNestedMeasurement) = Timer._measureFirst(instance)
+    
     if hasNestedMeasurement {
       // We can't do iterating measurements. Loop over individual
       // measurements until we satisfy requirements.


### PR DESCRIPTION
The monotonic clock has resolution of 42ns on the M1, which can be a bit longer than some benchmark tasks at small sizes, leading to measurements of 0s.

When this happens, round things up to the timer resolution.

Resolves https://github.com/apple/swift-collections/issues/5

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [X] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).
