### PR TITLE
[library render]: Sanitize generated filenames

### DIFF
--- a/Sources/CollectionsBenchmark/BenchmarkCLI/BenchmarkCLI+Library+Render.swift
+++ b/Sources/CollectionsBenchmark/BenchmarkCLI/BenchmarkCLI+Library+Render.swift
@@ -108,8 +108,7 @@ extension _BenchmarkCLI.Library {
               withIntermediateDirectories: true)
 
             let filename = "\(number) \(chart.title).\(format)"
-              .replacingOccurrences(of: "/", with: "-")
-            url.appendPathComponent(filename)
+            url.appendPathComponent(filename._sanitizedPathComponent())
             print("  \(url.relativePath)")
 
             let data = try renderer.render(

--- a/Tests/CollectionsBenchmarkTests/UtilitiesTests.swift
+++ b/Tests/CollectionsBenchmarkTests/UtilitiesTests.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+
+import XCTest
+@testable import CollectionsBenchmark
+
+final class UtilitiesTests: XCTestCase {
+  func testSanitizedPathComponent() {
+    func check(
+      _ input: String,
+      _ output: String,
+      windows: String? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      #if os(Windows)
+      XCTAssertEqual(
+        input._sanitizedPathComponent(),
+        windows ?? output,
+        file: file, line: line)
+      #else
+      XCTAssertEqual(
+        input._sanitizedPathComponent(),
+        output,
+        file: file, line: line)
+      #endif
+    }
+    check("", "")
+    check("Hello", "Hello")
+    check("Hello/goodbye", "Hello_goodbye")
+    check("Hello\u{0}goodbye", "Hello_goodbye")
+    check("Hello//goodbye", "Hello_goodbye")
+    check("Hello///////goodbye", "Hello_goodbye")
+    check("Hello/\u{0}/\u{0}/\u{0}/\u{0}goodbye", "Hello_goodbye")
+    check("/\u{0}/\u{0}/\u{0}/\u{0}", "_")
+
+    check(".", ".")
+    check("..", "..")
+    check("CON", "CON")
+    check("LPT7", "LPT7")
+    check(
+      "Some\\systems:have<trouble>with\"reasonable*filenames|like?this",
+      "Some\\systems:have<trouble>with\"reasonable*filenames|like?this",
+      windows: "Some_systems_have_trouble_with_reasonable_filenames_like_this")
+    check("Hi/:/*/bye", "Hi_:_*_bye", windows: "Hi_bye")
+  }
+}


### PR DESCRIPTION
Prevent reasonable chart titles such as `std::deque<int> append/remove` from generating invalid filenames when rendering libraries on Windows.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering my changes (if appropriate).
- [X] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).
