### PR TITLE
Correct benchmark typo

### DIFF
--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -31,7 +31,7 @@ This is where this package comes in -- it lets us easily create, run, and analyz
 ### Defining Benchmarks
 
 The `CollectionsBenchmark` library makes it easy to add an executable target for running, collecting, visualizing, and comparing benchmarks from the command line.
-The following example illustrates creating a benchamrk, included as [`main.swift`](./Example/Sources/kalimba-benchmark/main.swift) in the [`Documentation/Example` directory](./Example) of this project:
+The following example illustrates creating a benchmark, included as [`main.swift`](./Example/Sources/kalimba-benchmark/main.swift) in the [`Documentation/Example` directory](./Example) of this project:
 
 ```swift
 import CollectionsBenchmark


### PR DESCRIPTION
“benchmark” was spelled incorrectly

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [ ] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [x] I've updated the documentation (if appropriate).
