### PR TITLE
Bring dependencies to source-stable versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
-          "version": "0.4.1"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-system",
         "state": {
           "branch": null,
-          "revision": "8ffa04c0a0592e6f4f9c30926dedd8fa1c5371f9",
-          "version": "0.0.1"
+          "revision": "39774ef16a6d91dee6f666b940e00ea202710cf7",
+          "version": "0.0.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -37,8 +37,8 @@ let package = Package(
     .library(name: "CollectionsBenchmark", targets: ["CollectionsBenchmark"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
-    .package(url: "https://github.com/apple/swift-system", from: "0.0.1"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
+    .package(url: "https://github.com/apple/swift-system", from: "0.0.3"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Some official projects are using source-stable dependencies while some are not. Bringing all to 1.x.y avoids dependency resolution conflicts.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [x] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).