### PR TITLE
Bump dependencies to latest revisions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-          "version": "1.0.1"
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-system",
         "state": {
           "branch": null,
-          "revision": "39774ef16a6d91dee6f666b940e00ea202710cf7",
-          "version": "0.0.3"
+          "revision": "025bcb1165deab2e20d4eaba79967ce73013f496",
+          "version": "1.2.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -37,8 +37,8 @@ let package = Package(
     .library(name: "CollectionsBenchmark", targets: ["CollectionsBenchmark"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
-    .package(url: "https://github.com/apple/swift-system", from: "0.0.3"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
+    .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Notably, this updates the swift-system dependency from 0.0.3 to 1.2.1, a version with source stability.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [ ] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).
