### PR TITLE
Host Documentation on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [CollectionsBenchmark]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Swift Collections Benchmark
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-collections-benchmark%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/apple/swift-collections-benchmark)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-collections-benchmark%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/apple/swift-collections-benchmark)
+
 This package lets you collect and easily visualize performance data about data structure implementations and collection algorithms. It was created to help develop the [Swift Collections] package, but it's useful for so much more!
 
 [Swift Collections]: https://github.com/apple/swift-collections


### PR DESCRIPTION
I've added a simple SPI manifest so that SPI can build and host the DocC documentation. For context see: https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/~/documentation/spimanifest/commonusecases#spiHosting

## Room For Further Improvement
This PR only adds SPI doc hosting. It makes no changes to the DocC itself.

Currently, this DocC documentation does not include articles like the contents of the Documentation directory, including the [Getting Started.md](https://github.com/apple/swift-collections-benchmark/blob/main/Documentation/01%20Getting%20Started.md). 

It would be valuable to include that in the DocC as well. I can do that in a future commit if you like. I just wanted to confirm the structure of how you all would like to do it. 

After SPI builds and hosts the documentation, it would be good to add that URL to the README, to make it easier to find. 

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering my changes (if appropriate).
- [x] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [x] I've updated the documentation (if appropriate).
