### PR TITLE
Fix example manifest in README.md making target executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let package = Package(
   ],
   targets: [
     // ... other targets ...
-    .target(
+    .executableTarget(
       name: "MyBenchmark",
       dependencies: [
         .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark"),


### PR DESCRIPTION
Make `.target` as `.executableTarget` in sample manifest in README.
Without this change it's impossible to run benchmark because there's build error:
```
error: '########': executable product 'benchmark' expects target 'benchmark' to be executable; an executable target requires a 'main.swift' file
 ```

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [x] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).
